### PR TITLE
Updated 'How to Use' so that the XML would show up when reading the READM

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ How to use
 
 Register the zipfile module with your application by editing 'tiapp.xml' and adding the module:
 
+```xml
 <modules>
 	<module version="0.1.20">zipfile</module>
 </modules>
-
+```
 
 Zip File Extraction Example
 =======


### PR DESCRIPTION
The <modules> & <module> tags in the 'How to Use' section were being swallowed up by the browser when reading the README.md on GitHub. This fixes the problem.
